### PR TITLE
Phase 1: Add Neon Postgres setup

### DIFF
--- a/.neon
+++ b/.neon
@@ -1,0 +1,4 @@
+{
+  "orgId": "org-lucky-firefly-88956320",
+  "projectId": "quiet-wind-79737117"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "rmend-web",
       "version": "0.1.0",
       "dependencies": {
+        "@neondatabase/serverless": "^1.1.0",
         "@reduxjs/toolkit": "^2.12.0",
         "bootstrap": "^4.6.0",
         "next": "^14.2.5",
@@ -1280,6 +1281,15 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@neondatabase/serverless": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.1.0.tgz",
+      "integrity": "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=19.0.0"
       }
     },
     "node_modules/@next/env": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@neondatabase/serverless": "^1.1.0",
     "@reduxjs/toolkit": "^2.12.0",
     "bootstrap": "^4.6.0",
     "next": "^14.2.5",


### PR DESCRIPTION
## Phase 1 of 3 — Neon backend for RMend-Web

First in a stack of three PRs wiring Neon into RMend-Web as the basis for the new backend.

### What this does
- Adds `@neondatabase/serverless` and the `.neon` project context (Neon project **RMend**, Postgres 18).
- `DATABASE_URL` (+ Neon vars) live in `.env.local` (gitignored, not committed).

### Verification
- Live `SELECT` verified against **Postgres 18.4 / neondb**.

### Stack
1. **This PR** → `main`
2. Phase 2: Next.js 16 upgrade → this branch
3. Phase 3: Neon Auth scaffold → Phase 2 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)